### PR TITLE
Allocate dummyFunc once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,15 @@
 import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
+const dummyFunc = () => null;
+
 export class ReactBadly extends PureComponent {
   state = {
     hasError: false,
   };
 
   componentDidCatch (error, info) {
-    const errorHandler = this.props.onError || (() => null);
+    const errorHandler = this.props.onError || dummyFunc;
 
     this.setState({ hasError: true, errorInformation: { error, info } }, () => {
       errorHandler(error, info);


### PR DESCRIPTION
This is probably the least effective optimization ever, but I think it's slightly more efficient to allocate the dummy function `() => null` once to a variable, so that all future instances of `ReactBadly` and calls of `componentDidCatch` don't have to redefine it.